### PR TITLE
change default namespace to openshift-tang-operator

### DIFF
--- a/bundle/manifests/tang-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tang-operator.clusterserviceversion.yaml
@@ -27,6 +27,7 @@ metadata:
     capabilities: Basic Install
     operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
+    operatorframework.io/suggested-namespace: openshift-tang-operator
   name: tang-operator.v0.0.24
   namespace: placeholder
 spec:

--- a/operator_configs/minimal-keyretrieve-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator

--- a/operator_configs/minimal-keyretrieve-multireplica-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve-multireplica-deletehiddenkeys/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator

--- a/operator_configs/minimal-keyretrieve-multireplica/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve-multireplica/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator

--- a/operator_configs/minimal-keyretrieve-refreshtimer/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve-refreshtimer/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator

--- a/operator_configs/minimal-keyretrieve-rotate/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve-rotate/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator

--- a/operator_configs/minimal-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
+++ b/operator_configs/minimal-keyretrieve/daemons_v1alpha1_clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: tang-operator-controller-manager
-  namespace: default
+  namespace: openshift-tang-operator


### PR DESCRIPTION
also added a suggested namespace to the csv, so that default operator
installation will just work
