### PR TITLE
Update multi-arch_images_build.yml

### DIFF
--- a/.github/workflows/multi-arch_images_build.yml
+++ b/.github/workflows/multi-arch_images_build.yml
@@ -65,7 +65,7 @@ jobs:
           buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-ppc64le
           buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-s390x
           
-     # Authenticate to container image registry to push the image
+# Authenticate to container image registry to push the image
       - name: Podman Login
         uses: redhat-actions/podman-login@v1
         with:

--- a/.github/workflows/multi-arch_images_build.yml
+++ b/.github/workflows/multi-arch_images_build.yml
@@ -1,0 +1,78 @@
+name: Multiarch build
+
+on:
+  push:
+
+env:
+  IMAGE_NAME: tang-operator
+  IMAGE_TAG: multi-arch
+  IMAGE_REGISTRY: quay.io
+  IMAGE_NAMESPACE: sec-eng-special
+
+jobs:
+  build:
+    name: Build and push multi-arch image
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: add checkout action...
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Build image linux/amd64
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: linux-amd64
+          arch: amd64
+          build-args: |
+            goarch=amd64
+          containerfiles: |
+            ./Dockerfile
+  
+      - name: Build image linux/ppc64le
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: linux-ppc64le
+          arch: ppc64le
+          build-args: |
+            goarch=ppc64le
+          containerfiles: |
+            ./Dockerfile
+
+      - name: Build image linux/s390x
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          tags: linux-s390x
+          arch: s390x
+          build-args: |
+            goarch=s390x
+          containerfiles: |
+            ./Dockerfile  
+            
+            
+      - name: Check images created
+        run: buildah images | grep '${{ env.IMAGE_NAME }}'
+
+      - name: Create and add to manifest
+        run: |
+          buildah manifest create ${{ env.IMAGE_NAME }}
+          buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-amd64
+          buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-ppc64le
+          buildah manifest add ${{ env.IMAGE_NAME }} ${{ env.IMAGE_NAME }}:linux-s390x
+          
+     # Authenticate to container image registry to push the image
+      - name: Podman Login
+        uses: redhat-actions/podman-login@v1
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PWD }}
+
+      - name: Push manifest
+        run: |          
+            podman manifest push ${{ env.IMAGE_NAME }}  ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}  --all

--- a/.github/workflows/multi-arch_images_build.yml
+++ b/.github/workflows/multi-arch_images_build.yml
@@ -1,7 +1,7 @@
 name: Multiarch build
 
 on:
-  push:
+  workflow_dispatch:
 
 env:
   IMAGE_NAME: tang-operator


### PR DESCRIPTION
Raising a PR for building multi-arch images through Github action CI.

Created Github CI which can have github action and qemu statis user on top of x86 arch and we are using binaries of Power and other archs which are enabling us to create Virtual env for those architectures by this way we are building multi-arch images.

Note: To make it work need to create below two secrets in github repo

- QUAY_USER ---> quay username
- QUAY_PWD ---> quay repo password