### PR TITLE
Avoid golangci-lint action execution on doc files

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,7 +3,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - '**.md'
+      - '.wordlist.txt'
   pull_request:
+    paths-ignore:
+      - '**.md'
+      - '.wordlist.txt'
 
 permissions:
   contents: read


### PR DESCRIPTION
Resolves: #130