### PR TITLE
Release version v1.0.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 1.0.0
+VERSION ?= 1.0.1
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Tang operator-bundle are:
 - v0.0.27: Update operator-sdk and supported Go version (1.19.6 and higher)
 - v0.0.28: Code refactor
 -  v1.0.0: GA release candidate
+-  v1.0.1: new GA release candidate. Update Go version (1.16->1.21) and dependencies
 
 ## Installation
 
@@ -104,23 +105,23 @@ operator-sdk installation is described in the [Links](#links) section.
 
 In order to deploy the latest version of the Tang operator, check latest released
 version in the [Versions](#versions) section, and install the appropriate version
-bundle. For example, in case latest version is **1.0.0**, the command to execute
+bundle. For example, in case latest version is **1.0.1**, the command to execute
 will be:
 
 ```bash
-$ operator-sdk run bundle quay.io/sec-eng-special/tang-operator-bundle:v1.0.0 --index-image=quay.io/operator-framework/opm:v1.23.0
-INFO[0008] Successfully created registry pod: quay-io-sec-eng-special-tang-operator-bundle-v1.0.0
+$ operator-sdk run bundle quay.io/sec-eng-special/tang-operator-bundle:v1.0.1 --index-image=quay.io/operator-framework/opm:v1.23.0
+INFO[0008] Successfully created registry pod: quay-io-sec-eng-special-tang-operator-bundle-v1.0.1
 INFO[0009] Created CatalogSource: tang-operator-catalog
 INFO[0009] OperatorGroup "operator-sdk-og" created
-INFO[0009] Created Subscription: tang-operator-v1.0.0-sub
-INFO[0011] Approved InstallPlan install-lqf9f for the Subscription: tang-operator-v1.0.0-sub
+INFO[0009] Created Subscription: tang-operator-v1.0.1-sub
+INFO[0011] Approved InstallPlan install-lqf9f for the Subscription: tang-operator-v1.0.1-sub
 INFO[0011] Waiting for ClusterServiceVersion to reach 'Succeeded' phase
-INFO[0012]   Waiting for ClusterServiceVersion "default/tang-operator.v1.0.0"
-INFO[0018]   Found ClusterServiceVersion "default/tang-operator.v1.0.0" phase: Pending
-INFO[0020]   Found ClusterServiceVersion "default/tang-operator.v1.0.0" phase: InstallReady
-INFO[0021]   Found ClusterServiceVersion "default/tang-operator.v1.0.0" phase: Installing
-INFO[0031]   Found ClusterServiceVersion "default/tang-operator.v1.0.0" phase: Succeeded
-INFO[0031] OLM has successfully installed "tang-operator.v1.0.0"
+INFO[0012]   Waiting for ClusterServiceVersion "default/tang-operator.v1.0.1"
+INFO[0018]   Found ClusterServiceVersion "default/tang-operator.v1.0.1" phase: Pending
+INFO[0020]   Found ClusterServiceVersion "default/tang-operator.v1.0.1" phase: InstallReady
+INFO[0021]   Found ClusterServiceVersion "default/tang-operator.v1.0.1" phase: Installing
+INFO[0031]   Found ClusterServiceVersion "default/tang-operator.v1.0.1" phase: Succeeded
+INFO[0031] OLM has successfully installed "tang-operator.v1.0.1"
 ```
 To install latest multi-arch image, execute:
 ```bash
@@ -136,10 +137,10 @@ your cluster takes long time to deploy. To do so, the option **--timeout** can b
 used (if not used, default time is 2m, which stands for two minutes):
 
 ```bash
-$ operator-sdk run bundle --timeout 3m quay.io/sec-eng-special/tang-operator-bundle:v1.0.0 --index-image=quay.io/operator-framework/opm:v1.23.0
-INFO[0008] Successfully created registry pod: quay-io-sec-eng-special-tang-operator-bundle-v1.0.0
+$ operator-sdk run bundle --timeout 3m quay.io/sec-eng-special/tang-operator-bundle:v1.0.1 --index-image=quay.io/operator-framework/opm:v1.23.0
+INFO[0008] Successfully created registry pod: quay-io-sec-eng-special-tang-operator-bundle-v1.0.1
 ...
-INFO[0031] OLM has successfully installed "tang-operator.v1.0.0"
+INFO[0031] OLM has successfully installed "tang-operator.v1.0.1"
 ```
 
 Additionally, correct Tang operator installation can be observed if an output like
@@ -149,7 +150,7 @@ the following is observed when prompting for installed pods:
 $ oc get pods
 NAME                                                READY STATUS    RESTARTS AGE
 dbbd1837106ec169542546e7ad251b95d27c3542eb0409c1e   0/1   Completed 0        82s
-quay-io-tang-operator-bundle-v1.0.0                1/1   Running   0        90s
+quay-io-tang-operator-bundle-v1.0.1                1/1   Running   0        90s
 tang-operator-controller-manager-5c9488d8dd-mgmsf   2/2   Running   0        52s
 ```
 
@@ -196,19 +197,19 @@ to be released, it is recommended to increase version appropriately.
 In this case, same version is used. Last released version can be observed in
 [Versions](#versions) section.
 
-To summarize, taking into account that the last released version is **v1.0.0**,
+To summarize, taking into account that the last released version is **v1.0.1**,
 compilation can be done with next command:
 
 ```bash
-$ make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.0"
+$ make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.1"
 ...
 Successfully built 4a88ba8e6426
-Successfully tagged sec-eng-special/tang-operator:v1.0.0
-docker push sec-eng-special/tang-operator:v1.0.0
+Successfully tagged sec-eng-special/tang-operator:v1.0.1
+docker push sec-eng-special/tang-operator:v1.0.1
 The push refers to repository [quay.io/sec-eng-special/tang-operator]
 79109912085a: Pushed
 417cb9b79ade: Layer already exists
-v1.0.0: digest: sha256:c97bed08ab71556542602b008888bdf23ce4afd86228a07 size: 739
+v1.0.1: digest: sha256:c97bed08ab71556542602b008888bdf23ce4afd86228a07 size: 739
 ```
 
 In case a new release is planned to be done, the steps to follow will be:
@@ -224,15 +225,15 @@ index 9a41c6a..db12a82 100644
 @@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the
 # standard setup, you can:
-# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=1.0.0)
-# - use environment variables to overwrite this value (e.g export VERSION=1.0.0)
+# - use the VERSION as arg of the bundle target (e.g make bundle VERSION=1.0.1)
+# - use environment variables to overwrite this value (e.g export VERSION=1.0.1)
 -VERSION ?= 0.0.27
-+VERSION ?= 1.0.0
++VERSION ?= 1.0.1
 ```
 
 Apart from previous changes, it is recommended to generate a "latest" tag for tang-operator bundle:
 ```bash
-$ docker tag quay.io/sec-eng-special/tang-operator-bundle:v1.0.0 quay.io/sec-eng-special/tang-operator-bundle:latest
+$ docker tag quay.io/sec-eng-special/tang-operator-bundle:v1.0.1 quay.io/sec-eng-special/tang-operator-bundle:latest
 $ docker push quay.io/sec-eng-special/tang-operator-bundle:latest
 ```
 
@@ -242,14 +243,14 @@ Compile Tang operator code, specifying new version,
 by using **make docker-build** command:
 
 ```bash
-$ make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.0"
+$ make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.1"
 ...
-Successfully tagged sec-eng-special/tang-operator:v1.0.0
-docker push sec-eng-special/tang-operator:v1.0.0
+Successfully tagged sec-eng-special/tang-operator:v1.0.1
+docker push sec-eng-special/tang-operator:v1.0.1
 The push refers to repository [quay.io/sec-eng-special/tang-operator]
 9ff8a4099c67: Pushed
 417cb9b79ade: Layer already exists
-v1.0.0: digest: sha256:01620ab19faae54fb382a2ff285f589cf0bde6e168f14f07 size: 739
+v1.0.1: digest: sha256:01620ab19faae54fb382a2ff285f589cf0bde6e168f14f07 size: 739
 ```
 
 - <ins>Bundle push</ins>:
@@ -259,15 +260,15 @@ the bundle with **make bundle**, specifying appropriate image,
 and push it with **make bundle-build bundle-push**:
 
 ```bash
-$ make bundle IMG="quay.io/sec-eng-special/tang-operator:v1.0.0"
-$ make bundle-build bundle-push BUNDLE_IMG="quay.io/sec-eng-special/tang-operator-bundle:v1.0.0"
+$ make bundle IMG="quay.io/sec-eng-special/tang-operator:v1.0.1"
+$ make bundle-build bundle-push BUNDLE_IMG="quay.io/sec-eng-special/tang-operator-bundle:v1.0.1"
 ...
-docker push sec-eng-special/tang-operator-bundle:v1.0.0
+docker push sec-eng-special/tang-operator-bundle:v1.0.1
 The push refers to repository [quay.io/sec-eng-special/tang-operator-bundle]
 02e3768cfc56: Pushed
 df0c8060d328: Pushed
 84774958bcf4: Pushed
-v1.0.0: digest: sha256:925c2f844f941db2b53ce45cba9db7ee0be613321da8f0f05d size: 939
+v1.0.1: digest: sha256:925c2f844f941db2b53ce45cba9db7ee0be613321da8f0f05d size: 939
 make[1]: Leaving directory '/home/user/RedHat/TASKS/TANG_OPERATOR/tang-operator'
 ```
 
@@ -307,15 +308,15 @@ In order to cross compile tang-operator, prepend **GOARCH** with required archit
 **make docker-build**:
 
 ```bash
-$ GOARCH=ppc64le make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.0"
+$ GOARCH=ppc64le make docker-build docker-push IMG="quay.io/sec-eng-special/tang-operator:v1.0.1"
 ...
 Successfully built 4a88ba8e6426
-Successfully tagged sec-eng-special/tang-operator:v1.0.0
-docker push sec-eng-special/tang-operator:v1.0.0
+Successfully tagged sec-eng-special/tang-operator:v1.0.1
+docker push sec-eng-special/tang-operator:v1.0.1
 The push refers to repository [quay.io/sec-eng-special/tang-operator]
 79109912085a: Pushed
 417cb9b79ade: Layer already exists
-v1.0.0: digest: sha256:c97bed08ab71556542602b008888bdf23ce4afd86228a07 size: 739
+v1.0.1: digest: sha256:c97bed08ab71556542602b008888bdf23ce4afd86228a07 size: 739
 ```
 
 ## Cleanup
@@ -325,9 +326,9 @@ recommended way:
 
 ```bash
 $ operator-sdk cleanup tang-operator
-INFO[0001] subscription "tang-operator-v1.0.0-sub" deleted
+INFO[0001] subscription "tang-operator-v1.0.1-sub" deleted
 INFO[0001] customresourcedefinition "tangservers.daemons.redhat.com" deleted
-INFO[0002] clusterserviceversion "tang-operator.v1.0.0" deleted
+INFO[0002] clusterserviceversion "tang-operator.v1.0.1" deleted
 INFO[0002] catalogsource "tang-operator-catalog" deleted
 INFO[0002] operatorgroup "operator-sdk-og" deleted
 INFO[0002] Operator "tang-operator" uninstalled
@@ -398,11 +399,11 @@ NOTE: CI/CD is in a continuous "work in progress" state
 
 ## Scorecard
 
-Execution of operator-sdk scorecard tests are passing completely in version v1.0.0.
+Execution of operator-sdk scorecard tests are passing completely in version v1.0.1.
 In order to execute these tests, run next command:
 
 ```bash
-$ operator-sdk scorecard -w 60s quay.io/sec-eng-special/tang-operator-bundle:v1.0.0
+$ operator-sdk scorecard -w 60s quay.io/sec-eng-special/tang-operator-bundle:v1.0.1
 ...
 Results:
 Name: olm-status-descriptors

--- a/bundle/manifests/tang-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tang-operator.clusterserviceversion.yaml
@@ -25,10 +25,10 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2023-10-05T08:04:13Z"
+    createdAt: "2023-10-09T13:22:34Z"
     operators.operatorframework.io/builder: operator-sdk-v1.28.1
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
-  name: tang-operator.v1.0.0
+  name: tang-operator.v1.0.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -321,7 +321,7 @@ spec:
                 - --leader-elect
                 command:
                 - /manager
-                image: quay.io/sec-eng-special/tang-operator:v1.0.0
+                image: quay.io/sec-eng-special/tang-operator:v1.0.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -404,4 +404,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  version: 1.0.0
+  version: 1.0.1

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/sec-eng-special/tang-operator
-  newTag: v1.0.0
+  newTag: v1.0.1


### PR DESCRIPTION
This is the new GA candidate, with
Go version updated to 1.21 and dependencies updates

Resolves: #174