### PR TITLE
Use URL instead of using Url

### DIFF
--- a/api/v1alpha1/tangserver_types.go
+++ b/api/v1alpha1/tangserver_types.go
@@ -173,10 +173,10 @@ type TangServerStatus struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text",displayName="Tang Server Ready Replicas"
 	// +optional
 	Ready uint32 `json:"ready"`
-	// Tang Server Service External Url provides information about the External Service Url
-	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text",displayName="Tang Server External Url"
+	// Tang Server Service External URL provides information about the External Service URL
+	// +operator-sdk:csv:customresourcedefinitions:type=status,xDescriptors="urn:alm:descriptor:text",displayName="Tang Server External URL"
 	// +optional
-	ServiceExternalUrl string `json:"serviceExternalUrl,omitempty"`
+	ServiceExternalURL string `json:"serviceExternalURL,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/bundle/manifests/daemons.redhat.com_tangservers.yaml
+++ b/bundle/manifests/daemons.redhat.com_tangservers.yaml
@@ -215,9 +215,9 @@ spec:
                   Replicas
                 format: int32
                 type: integer
-              serviceExternalUrl:
-                description: Tang Server Service External Url provides information
-                  about the External Service Url
+              serviceExternalURL:
+                description: Tang Server Service External URL provides information
+                  about the External Service URL
                 type: string
               tangServerError:
                 description: TangServerError collects error on Tang Operator creation

--- a/bundle/manifests/tang-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/tang-operator.clusterserviceversion.yaml
@@ -164,10 +164,10 @@ spec:
         path: running
         x-descriptors:
         - urn:alm:descriptor:text
-      - description: Tang Server Service External Url provides information about the
-          External Service Url
-        displayName: Tang Server External Url
-        path: serviceExternalUrl
+      - description: Tang Server Service External URL provides information about the
+          External Service URL
+        displayName: Tang Server External URL
+        path: serviceExternalURL
         x-descriptors:
         - urn:alm:descriptor:text
       - description: TangServerError collects error on Tang Operator creation

--- a/config/crd/bases/daemons.redhat.com_tangservers.yaml
+++ b/config/crd/bases/daemons.redhat.com_tangservers.yaml
@@ -216,9 +216,9 @@ spec:
                   Replicas
                 format: int32
                 type: integer
-              serviceExternalUrl:
-                description: Tang Server Service External Url provides information
-                  about the External Service Url
+              serviceExternalURL:
+                description: Tang Server Service External URL provides information
+                  about the External Service URL
                 type: string
               tangServerError:
                 description: TangServerError collects error on Tang Operator creation

--- a/config/manifests/bases/tang-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/tang-operator.clusterserviceversion.yaml
@@ -129,10 +129,10 @@ spec:
         path: running
         x-descriptors:
         - urn:alm:descriptor:text
-      - description: Tang Server Service External Url provides information about the
-          External Service Url
-        displayName: Tang Server External Url
-        path: serviceExternalUrl
+      - description: Tang Server Service External URL provides information about the
+          External Service URL
+        displayName: Tang Server External URL
+        path: serviceExternalURL
         x-descriptors:
         - urn:alm:descriptor:text
       - description: TangServerError collects error on Tang Operator creation

--- a/controllers/tangserver_controller.go
+++ b/controllers/tangserver_controller.go
@@ -485,7 +485,7 @@ func (r *TangServerReconciler) reconcileService(cr *daemonsv1alpha1.TangServer) 
 		GetLogInstance().Info("Service already exists", "Service.Namespace", serviceFound.Namespace, "Service.Name", serviceFound.Name)
 		if len(serviceFound.Status.LoadBalancer.Ingress) > 0 {
 			GetLogInstance().Info("Service Information", "Load Balancer IP", serviceFound.Status.LoadBalancer.Ingress[0].IP, "Load Balancer Hostname", serviceFound.Status.LoadBalancer.Ingress[0].Hostname)
-			cr.Status.ServiceExternalUrl = getExternalServiceUrl(cr, serviceFound.Status.LoadBalancer.Ingress[0])
+			cr.Status.ServiceExternalURL = getExternalServiceURL(cr, serviceFound.Status.LoadBalancer.Ingress[0])
 			err := r.Client.Status().Update(context.Background(), cr)
 			if err != nil {
 				GetLogInstance().Error(err, "Unable to update TangServer status with Service IP URL")

--- a/controllers/tangserver_controller_service.go
+++ b/controllers/tangserver_controller_service.go
@@ -81,17 +81,17 @@ func getService(tangserver *daemonsv1alpha1.TangServer) *corev1.Service {
 }
 
 // getService function returns correctly created service
-func getServiceUrl(tangserver *daemonsv1alpha1.TangServer) string {
+func getServiceURL(tangserver *daemonsv1alpha1.TangServer) string {
 	return DEFAULT_SERVICE_PROTO + "://" + getServiceName(tangserver) + "." + tangserver.Namespace + ":" + fmt.Sprint(getServicePort(tangserver)) + "/adv"
 }
 
-// getServiceIpUrl function returns correctly created service
-func getServiceIpUrl(tangserver *daemonsv1alpha1.TangServer, ip string) string {
+// getServiceIpURL function returns correctly created service
+func getServiceIpURL(tangserver *daemonsv1alpha1.TangServer, ip string) string {
 	return DEFAULT_SERVICE_PROTO + "://" + ip + ":" + fmt.Sprint(getServicePort(tangserver)) + "/adv"
 }
 
-// getExternalServiceUrl function returns correctly created service
-func getExternalServiceUrl(tangserver *daemonsv1alpha1.TangServer, balancer corev1.LoadBalancerIngress) string {
+// getExternalServiceURL function returns correctly created service
+func getExternalServiceURL(tangserver *daemonsv1alpha1.TangServer, balancer corev1.LoadBalancerIngress) string {
 	if len(balancer.Hostname) > 0 {
 		return DEFAULT_SERVICE_PROTO + "://" + balancer.Hostname + ":" + fmt.Sprint(getServicePort(tangserver)) + "/adv"
 	} else {

--- a/controllers/tangserver_controller_service_test.go
+++ b/controllers/tangserver_controller_service_test.go
@@ -97,21 +97,21 @@ var _ = Describe("TangServer controller service", func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, tangServer)).Should(Succeed())
-			serviceUrl := getServiceUrl(tangServer)
-			Expect(len(serviceUrl) > 0)
-			serviceIpUrl := getServiceIpUrl(tangServer, TangServerTestIp)
-			Expect(len(serviceIpUrl) > 0)
-			Expect(strings.Contains(serviceIpUrl, TangServerTestIp))
+			serviceURL := getServiceURL(tangServer)
+			Expect(len(serviceURL) > 0)
+			serviceIpURL := getServiceIpURL(tangServer, TangServerTestIp)
+			Expect(len(serviceIpURL) > 0)
+			Expect(strings.Contains(serviceIpURL, TangServerTestIp))
 			loadBalancer := corev1.LoadBalancerIngress{
 				Hostname: TangServerTestHostname,
 			}
-			serviceIpExternalServiceUrl := getExternalServiceUrl(tangServer, loadBalancer)
-			Expect(strings.Contains(serviceIpExternalServiceUrl, TangServerTestHostname))
+			serviceIpExternalServiceURL := getExternalServiceURL(tangServer, loadBalancer)
+			Expect(strings.Contains(serviceIpExternalServiceURL, TangServerTestHostname))
 			loadBalancer = corev1.LoadBalancerIngress{
 				IP: TangServerTestIp,
 			}
-			serviceIpExternalServiceUrl = getExternalServiceUrl(tangServer, loadBalancer)
-			Expect(strings.Contains(serviceIpExternalServiceUrl, TangServerTestIp))
+			serviceIpExternalServiceURL = getExternalServiceURL(tangServer, loadBalancer)
+			Expect(strings.Contains(serviceIpExternalServiceURL, TangServerTestIp))
 			err := k8sClient.Delete(ctx, tangServer)
 			Expect(err, nil)
 		})

--- a/tools/api_tools/show_keys.sh
+++ b/tools/api_tools/show_keys.sh
@@ -54,17 +54,17 @@ done
 test -z "${namespace}" && namespace="default"
 test -z "${oc_client}" && oc_client="oc"
 
-getAdvUrl() {
+getAdvURL() {
   if [ "${using_minikube}" != "yes" ];
   then
-      "${oc_client}" -n "${namespace}" get tangservers.daemons.redhat.com  -o json | jq '.items[0].status.serviceExternalUrl' | tr -d '"'
+      "${oc_client}" -n "${namespace}" get tangservers.daemons.redhat.com  -o json | jq '.items[0].status.serviceExternalURL' | tr -d '"'
   else
       port=$("${oc_client}" -n "${namespace}" get service -o json | jq '.items[0].spec.ports[0].nodePort')
       echo "http://$(minikube ip):${port}/adv"
   fi
 }
 
-adv_url=$(getAdvUrl)
+adv_url=$(getAdvURL)
 adv=$(wget -O - "${adv_url}" -o /dev/null)
 
 dumpFromAdvWithHash() {


### PR DESCRIPTION
URL is preferred to Url when referring to
Uniform Resource Locator

Resolves: #206