### PR TITLE
Avoid warnings in Github Action: checkout update

### DIFF
--- a/.github/workflows/multi-arch_images_build.yaml
+++ b/.github/workflows/multi-arch_images_build.yaml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: add checkout action...
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v1


### PR DESCRIPTION
This change allows fixing the warnings dumped in
Github Multi Arch build Action by upgrading checkout Github Action to v3

Resolves: #216