### PR TITLE
Enable Cluster tests again

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,8 +37,8 @@ jobs:
     - name: Status
       run: minikube status
 
-    #- name: Cluster Test
-    #  run: CLUSTER_TANG_OPERATOR_TEST=1 make test
+    - name: Cluster Test
+      run: CLUSTER_TANG_OPERATOR_TEST=1 make test
 
     - name: Deploy and Scorecard
       run: |


### PR DESCRIPTION
After latest Golang version update (1.21.7), cluster tests are working again with no crashes

Resolves: #92